### PR TITLE
feat(renovate-preset): add default renovate preset

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -1,0 +1,16 @@
+{
+  extends: ["config:base", ":disableRateLimiting"],
+  lockFileMaintenance: {
+    enabled: true,
+  },
+  labels: ["dependencies", "renovatebot"],
+  packageRules: [
+    {
+      extends: ["group:allNonMajor", "schedule:weekly"],
+      lockFileMaintenance: {
+        enabled: true,
+      },
+      depTypeList: ["devDependencies"],
+    },
+  ],
+}


### PR DESCRIPTION
This is the initial proposal for a renovate shared configuration for Simplabs' Open Source repositories. Then main goal is to group all the minor dev dependency updates to reduce PR noise.

This configuration is retrieved from here: https://github.com/simplabs/gravity/blob/master/renovate.json