### PR TITLE
refactor(renovate): restore .json5 configuration

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -1,0 +1,16 @@
+{
+  extends: ["config:base", ":disableRateLimiting", ":preserveSemverRanges"],
+  lockFileMaintenance: {
+    enabled: true,
+  },
+  labels: ["dependencies", "renovatebot"],
+  packageRules: [
+    {
+      extends: ["group:allNonMajor", "schedule:weekly"],
+      lockFileMaintenance: {
+        enabled: true,
+      },
+      depTypeList: ["devDependencies"],
+    },
+  ],
+}


### PR DESCRIPTION
.JSON5 presets are supported now: https://github.com/renovatebot/renovate/issues/15370

Preserving `default.json` until the existing repositories have migrated to the new `.json5` preset.

Fixes https://github.com/simplabs/renovate-config/issues/6

Created follow up issue to clean `default.json` preset.